### PR TITLE
Paths normalization

### DIFF
--- a/zotfile_doctor.py
+++ b/zotfile_doctor.py
@@ -22,6 +22,7 @@ import os
 import pathlib
 import re
 import sqlite3
+import tempfile
 import unicodedata
 
 

--- a/zotfile_doctor.py
+++ b/zotfile_doctor.py
@@ -46,7 +46,7 @@ def get_db_set(db, d):
             # file is not in zotfile directory
             continue
 
-        db_l.append(unicodedata.normalize("NFD", item))
+        db_l.append(os.path.normpath(unicodedata.normalize("NFD", item)))
         
     db_set = set(db_l)
     return db_set
@@ -60,7 +60,7 @@ def get_dir_set(d):
             matches.append(os.path.join(root, filename))
 
     fs = [str(pathlib.Path(f).relative_to(d)) for f in matches]
-    fs = [unicodedata.normalize("NFD", x) for x in fs]
+    fs = [os.path.normpath(unicodedata.normalize("NFD", x)) for x in fs]
     d_set = set(fs)
     return d_set
 

--- a/zotfile_doctor.py
+++ b/zotfile_doctor.py
@@ -23,6 +23,13 @@ import fnmatch
 import os
 import pathlib
 import re
+import tempfile
+
+
+def is_fs_case_sensitive():
+    with tempfile.NamedTemporaryFile(prefix='TmP') as tmp_file:
+        return(not os.path.exists(tmp_file.name.lower()))
+
 
 def get_db_set(db, d):
     conn = sqlite3.connect(db)
@@ -68,7 +75,11 @@ def get_dir_set(d):
 def main(db, d):
     db_set = get_db_set(db, d)
     dir_set = get_dir_set(d)
-
+    
+    if not is_fs_case_sensitive():
+        db_set  = set(map(str.lower, db_set))
+        dir_set = set(map(str.lower, dir_set))
+    
     db_not_dir = db_set.difference(dir_set)
     dir_not_db = dir_set.difference(db_set)
 

--- a/zotfile_doctor.py
+++ b/zotfile_doctor.py
@@ -16,18 +16,17 @@
 
 """Checks the consistency between the zotfile-managed directory and the database"""
 
-import sqlite3
-import sys
-import unicodedata
+import argparse
 import fnmatch
 import os
 import pathlib
 import re
-import tempfile
+import sqlite3
+import unicodedata
 
 
-def is_fs_case_sensitive(path):
-    with tempfile.NamedTemporaryFile(prefix='TmP', dir=path) as tmp_file:
+def is_fs_case_sensitive(d):
+    with tempfile.NamedTemporaryFile(prefix='TmP', dir=d) as tmp_file:
         return(not os.path.exists(tmp_file.name.lower()))
 
 
@@ -39,7 +38,7 @@ def get_db_set(db, d):
     db_d = db_c.fetchall()
 
     db_l = []
-    for i in range(len(db_d)):
+    for i, _ in enumerate(db_d):
         try:
             # Ignore all kind of errors wholesale, i.e. duck typing
             item = db_d[i][0]
@@ -54,15 +53,14 @@ def get_db_set(db, d):
             continue
 
         db_l.append(os.path.normpath(unicodedata.normalize("NFD", item)))
-        
+
     db_set = set(db_l)
     return db_set
-
 
 def get_dir_set(d):
     rule = re.compile(fnmatch.translate("*.pdf"), re.IGNORECASE)
     matches = []
-    for root, dirnames, filenames in os.walk(d):
+    for root, _dirnames, filenames in os.walk(d):
         for filename in [name for name in filenames if rule.match(name)]:
             matches.append(os.path.join(root, filename))
 
@@ -71,34 +69,44 @@ def get_dir_set(d):
     d_set = set(fs)
     return d_set
 
+def remove_empty_dirs(d):
+    for root, dirnames, _filenames in os.walk(d, topdown=False):
+        for dirname in dirnames:
+            try:
+                os.rmdir(os.path.realpath(os.path.join(root, dirname)))
+            except OSError:
+                continue
 
-def main(db, d):
+def main(db, d, clean=False):
     db_set = get_db_set(db, d)
     dir_set = get_dir_set(d)
-    
+
     if not is_fs_case_sensitive(d):
         db_set  = set(map(str.lower, db_set))
         dir_set = set(map(str.lower, dir_set))
-    
+
     db_not_dir = db_set.difference(dir_set)
     dir_not_db = dir_set.difference(db_set)
 
-    print(
-        f"There were {len(db_not_dir)}/{len(db_set)} files in DB but not in zotfile directory:")
+    print(f"There were {len(db_not_dir)}/{len(db_set)} files in DB but not in zotfile directory:")
     for f in sorted(db_not_dir):
         print("   " + f)
-
-    print("\n")
-    print(
-        f"There were {len(dir_not_db)}/{len(dir_set)} files in zotfile directory but not in DB:")
+    print(f"\nThere were {len(dir_not_db)}/{len(dir_set)} files in zotfile directory but not in DB:")
     for f in sorted(dir_not_db):
         print("   " + f)
 
+    if clean and len(dir_not_db) > 0:
+        for f in dir_not_db:
+            os.remove(os.path.join(d, f))
+        remove_empty_dirs(d)
+        print(f"\n{len(dir_not_db)} files and empty directories has been removed")
+
 
 if __name__ == "__main__":
-    if len(sys.argv) != 3:
-        print(f"Usage: {sys.argv[0]} zotero.sqlite zotfile_directory")
-        sys.exit(1)
-
-    main(sys.argv[1],
-         sys.argv[2])
+    parser = argparse.ArgumentParser(description="zotfile directory consistency checker")
+    parser.add_argument("zotero_sqlite", help="path-to-zotero/zotero.sqlite")
+    parser.add_argument("zotfile_directory", help="zotfile directory")
+    parser.add_argument("-c", "--clean", action="store_true",
+                        help="remove files in zotfile directory but not in DB")
+    args = parser.parse_args()
+    main(args.zotero_sqlite, args.zotfile_directory, args.clean)

--- a/zotfile_doctor.py
+++ b/zotfile_doctor.py
@@ -26,8 +26,8 @@ import re
 import tempfile
 
 
-def is_fs_case_sensitive():
-    with tempfile.NamedTemporaryFile(prefix='TmP') as tmp_file:
+def is_fs_case_sensitive(path):
+    with tempfile.NamedTemporaryFile(prefix='TmP', dir=path) as tmp_file:
         return(not os.path.exists(tmp_file.name.lower()))
 
 
@@ -76,7 +76,7 @@ def main(db, d):
     db_set = get_db_set(db, d)
     dir_set = get_dir_set(d)
     
-    if not is_fs_case_sensitive():
+    if not is_fs_case_sensitive(d):
         db_set  = set(map(str.lower, db_set))
         dir_set = set(map(str.lower, dir_set))
     


### PR DESCRIPTION
1. I've added a paths normalization to cope with the problem which occured for me in Win10: links in my Zotero DB use slashes as path separator, while Win10 uses backslashes.
2. I've added a simple check (by Steve Cohen: https://stackoverflow.com/a/36580834) of whether the file system of the Zotero dir is case sensitive. If no I convert all paths to lowercase. This eliminates possible upper/lowercase problems in case insensitive file systems.