### PR TITLE
Normpath

### DIFF
--- a/zotfile_doctor.py
+++ b/zotfile_doctor.py
@@ -23,7 +23,11 @@ import pathlib
 import re
 import sqlite3
 import unicodedata
+import tempfile
 
+def is_fs_case_sensitive():
+    with tempfile.NamedTemporaryFile(prefix='TmP') as tmp_file:
+        return(not os.path.exists(tmp_file.name.lower()))
 
 def get_db_set(db, d):
     conn = sqlite3.connect(db)
@@ -47,7 +51,7 @@ def get_db_set(db, d):
             # file is not in zotfile directory
             continue
 
-        db_l.append(unicodedata.normalize("NFD", item))
+        db_l.append(os.path.normpath(unicodedata.normalize("NFD", item)))
 
     db_set = set(db_l)
     return db_set
@@ -60,7 +64,7 @@ def get_dir_set(d):
             matches.append(os.path.join(root, filename))
 
     fs = [str(pathlib.Path(f).relative_to(d)) for f in matches]
-    fs = [unicodedata.normalize("NFD", x) for x in fs]
+    fs = [os.path.normpath(unicodedata.normalize("NFD", x)) for x in fs]
     d_set = set(fs)
     return d_set
 
@@ -75,6 +79,10 @@ def remove_empty_dirs(d):
 def main(db, d, clean=False):
     db_set = get_db_set(db, d)
     dir_set = get_dir_set(d)
+
+    if not is_fs_case_sensitive():
+        db_set  = set(map(str.lower, db_set))
+        dir_set = set(map(str.lower, dir_set))
 
     db_not_dir = db_set.difference(dir_set)
     dir_not_db = dir_set.difference(db_set)

--- a/zotfile_doctor.py
+++ b/zotfile_doctor.py
@@ -25,8 +25,8 @@ import sqlite3
 import unicodedata
 import tempfile
 
-def is_fs_case_sensitive():
-    with tempfile.NamedTemporaryFile(prefix='TmP') as tmp_file:
+def is_fs_case_sensitive(d):
+    with tempfile.NamedTemporaryFile(prefix='TmP', dir=d) as tmp_file:
         return(not os.path.exists(tmp_file.name.lower()))
 
 def get_db_set(db, d):
@@ -80,7 +80,7 @@ def main(db, d, clean=False):
     db_set = get_db_set(db, d)
     dir_set = get_dir_set(d)
 
-    if not is_fs_case_sensitive():
+    if not is_fs_case_sensitive(d):
         db_set  = set(map(str.lower, db_set))
         dir_set = set(map(str.lower, dir_set))
 


### PR DESCRIPTION
Hello again.

Let me explain what the changes do:

First, we create a temporary file in Zotero directory with `pdf`s (that addresses your complint in previous PR). The name contains both uppercase and lowercase letters. Then we check whether the file with lowercase name exists. If yes, then the filesystem is case-insensitive. If that's the case then we convert all names in `db_set` and `dir_set` to lowercase for convenience of filename checking. If the FS is case-sensitive then we do nothing.

Second, I've added `os.path.normpath` calls while adding entries to `db_set` and `dir_set` to make path delimiters consistent in both sets as Zotero Database uses Unix-like path delimiter (/) whle windows uses (\\). `os.path.normpath` changes path delimiters in path strings to os default. On Linux it will replace '/' with '/', in other words do nothing.

Hope I've managed to explain my changes in clear way.